### PR TITLE
Added word wrapping functionality to draw multiline text with a specified line length

### DIFF
--- a/libsftd/include/sftd.h
+++ b/libsftd/include/sftd.h
@@ -105,6 +105,38 @@ void sftd_draw_wtext(sftd_font *font, int x, int y, unsigned int color, unsigned
  */
 void sftd_draw_wtextf(sftd_font *font, int x, int y, unsigned int color, unsigned int size, const wchar_t *text, ...);
 
+/**
+ * @brief Returns the width of the given text in pixels
+ * @param font the font used to calculate the width
+ * @param size the font size
+ * @param text a pointer to the text that will be used to calculate the length
+ */
+int sftd_get_text_width(sftd_font *font, unsigned int size, char *text);
+
+/**
+ * @brief Draws text using a font. The text will wrap after the pixels specified in lineWidth.
+ * @param font the font to use
+ * @param x the x coordinate to draw the text to
+ * @param y the y coordinate to draw the text to
+ * @param color the color to draw the font
+ * @param size the font size
+ * @param lineWidth The length of one line before a line break accours.
+ * @param text a pointer to the text to draw
+ */
+void sftd_draw_text_wrap(sftd_font *font, int x, int y, unsigned int color, unsigned int size, unsigned int lineWidth, const char *text);
+
+/**
+ * @brief Draws formatted text using a font.  The text will wrap after the pixels specified in lineWidth.
+ * @param font the font to use
+ * @param x the x coordinate to draw the text to
+ * @param y the y coordinate to draw the text to
+ * @param color the color to draw the font
+ * @param size the font size
+ * @param lineWidth The length of one line before a line break accours.
+ * @param text a pointer to the text to draw
+ * @param ... variable arguments
+ */
+void sftd_draw_textf_wrap(sftd_font *font, int x, int y, unsigned int color, unsigned int size, unsigned int lineWidth, const char *text, ...);
 
 #ifdef __cplusplus
 }

--- a/libsftd/include/sftd.h
+++ b/libsftd/include/sftd.h
@@ -126,6 +126,17 @@ int sftd_get_text_width(sftd_font *font, unsigned int size, char *text);
 void sftd_draw_text_wrap(sftd_font *font, int x, int y, unsigned int color, unsigned int size, unsigned int lineWidth, const char *text);
 
 /**
+ * @brief Calculates the bounding box of the text wih the given attributes.
+ * @param boundingWidth Pointer to the address where the width will be stored.
+ * @param boundingHeight Pointer to the address where the height will be stored.
+ * @param font the font to use
+ * @param size the font size
+ * @param lineWidth The length of one line before a line break accours.
+ * @param text a pointer to the text to draw
+ */
+void sftd_calc_bounding_box(int *boundingWidth, int *boundingHeight, sftd_font *font, unsigned int size, unsigned int lineWidth, const char *text);
+
+/**
  * @brief Draws formatted text using a font.  The text will wrap after the pixels specified in lineWidth.
  * @param font the font to use
  * @param x the x coordinate to draw the text to

--- a/libsftd/source/sftd.c
+++ b/libsftd/source/sftd.c
@@ -4,6 +4,7 @@
 #include <wchar.h>
 #include <sf2d.h>
 #include <ft2build.h>
+#include <string.h>
 #include FT_CACHE_H
 #include FT_FREETYPE_H
 
@@ -245,6 +246,7 @@ void sftd_draw_text(sftd_font *font, int x, int y, unsigned int color, unsigned 
 		text++;
 	}
 }
+
 void sftd_draw_textf(sftd_font *font, int x, int y, unsigned int color, unsigned int size, const char *text, ...)
 {
 	char buffer[256];
@@ -332,3 +334,164 @@ void sftd_draw_wtextf(sftd_font *font, int x, int y, unsigned int color, unsigne
 	va_end(args);
 }
 
+int sftd_get_text_width(sftd_font *font, unsigned int size, char *text) {
+	FTC_FaceID face_id = (FTC_FaceID)font;
+	FT_Face face;
+	FTC_Manager_LookupFace(ftcmanager, face_id, &face);
+
+	FT_Int charmap_index;
+	charmap_index = FT_Get_Charmap_Index(face->charmap);
+
+	FT_Glyph glyph;
+	FT_Bool use_kerning = FT_HAS_KERNING(face);
+	FT_UInt glyph_index, previous = 0;
+	int pen_x = 0;
+	int pen_y = size;
+
+	FTC_ScalerRec scaler;
+	scaler.face_id = face_id;
+	scaler.width = size;
+	scaler.height = size;
+	scaler.pixel = 1;
+
+	FT_ULong flags = FT_LOAD_RENDER | FT_LOAD_TARGET_NORMAL;
+
+	while (*text) {
+		glyph_index = FTC_CMapCache_Lookup(font->cmapcache, (FTC_FaceID)font, charmap_index, *text);
+
+		if (use_kerning && previous && glyph_index) {
+			FT_Vector delta;
+			FT_Get_Kerning(face, previous, glyph_index, FT_KERNING_DEFAULT, &delta);
+			pen_x += delta.x >> 6;
+		}
+
+		if (!texture_atlas_exists(font->tex_atlas, glyph_index)) {
+			FTC_ImageCache_LookupScaler(font->imagecache, &scaler, flags, glyph_index, &glyph, NULL);
+
+			if (!atlas_add_glyph(font->tex_atlas, glyph_index, (FT_BitmapGlyph)glyph, size)) {
+				continue;
+			}
+		}
+
+		bp2d_rectangle rect;
+		int bitmap_left, bitmap_top;
+		int advance_x, advance_y;
+		int glyph_size;
+
+		texture_atlas_get(font->tex_atlas, glyph_index,
+			&rect, &bitmap_left, &bitmap_top,
+			&advance_x, &advance_y, &glyph_size);
+
+		const float draw_scale = size/(float)glyph_size;
+
+		pen_x += (advance_x >> 16) * draw_scale;
+		pen_y += (advance_y >> 16) * draw_scale;
+
+		previous = glyph_index;
+		text++;
+	}
+	return pen_x;
+}
+
+void sftd_draw_text_wrap(sftd_font *font, int x, int y, unsigned int color, unsigned int size, unsigned int lineWidth, const char *text)
+{
+	FTC_FaceID face_id = (FTC_FaceID)font;
+	FT_Face face;
+	FTC_Manager_LookupFace(ftcmanager, face_id, &face);
+
+	FT_Int charmap_index;
+	charmap_index = FT_Get_Charmap_Index(face->charmap);
+
+	FT_Glyph glyph;
+	FT_Bool use_kerning = FT_HAS_KERNING(face);
+	FT_UInt glyph_index, previous = 0;
+	int pen_x = x;
+	int pen_y = y + size;
+
+	FTC_ScalerRec scaler;
+	scaler.face_id = face_id;
+	scaler.width = size;
+	scaler.height = size;
+	scaler.pixel = 1;
+
+	FT_ULong flags = FT_LOAD_RENDER | FT_LOAD_TARGET_NORMAL;
+
+	bool isFirstLine = true;
+	char buffer[strlen(text)];
+	sprintf(buffer, text);
+	char *currentWord;
+	int currentWordLength;
+	int currentCharIndex;
+
+	currentWord = strtok(buffer, " ");
+	while (currentWord) {
+		currentWordLength = strlen(currentWord);
+		if(pen_x + sftd_get_text_width(font, size, currentWord) >= lineWidth && !isFirstLine) {
+			pen_x = x;
+			pen_y += size;
+		}
+		isFirstLine = false;
+		for(currentCharIndex = 0; currentCharIndex < currentWordLength + 1; currentCharIndex++) {
+			if(currentCharIndex < currentWordLength) {
+				glyph_index = FTC_CMapCache_Lookup(font->cmapcache, (FTC_FaceID)font, charmap_index, currentWord[currentCharIndex]);
+			}
+			else {
+				glyph_index = FTC_CMapCache_Lookup(font->cmapcache, (FTC_FaceID)font, charmap_index, ' ');
+			}
+			
+			// TODO get word size and linewrap if needed
+
+			if (use_kerning && previous && glyph_index) {
+				FT_Vector delta;
+				FT_Get_Kerning(face, previous, glyph_index, FT_KERNING_DEFAULT, &delta);
+				pen_x += delta.x >> 6;
+			}
+
+			if (!texture_atlas_exists(font->tex_atlas, glyph_index)) {
+				FTC_ImageCache_LookupScaler(font->imagecache, &scaler, flags, glyph_index, &glyph, NULL);
+
+				if (!atlas_add_glyph(font->tex_atlas, glyph_index, (FT_BitmapGlyph)glyph, size)) {
+					continue;
+				}
+			}
+
+			bp2d_rectangle rect;
+			int bitmap_left, bitmap_top;
+			int advance_x, advance_y;
+			int glyph_size;
+
+			texture_atlas_get(font->tex_atlas, glyph_index,
+				&rect, &bitmap_left, &bitmap_top,
+				&advance_x, &advance_y, &glyph_size);
+
+			const float draw_scale = size/(float)glyph_size;
+
+			sf2d_draw_texture_part_scale_blend(font->tex_atlas->tex,
+				pen_x + bitmap_left * draw_scale,
+				pen_y - bitmap_top * draw_scale,
+				rect.x, rect.y, rect.w, rect.h,
+				draw_scale,
+				draw_scale,
+				color);
+
+			pen_x += (advance_x >> 16) * draw_scale;
+			pen_y += (advance_y >> 16) * draw_scale;
+
+			
+			previous = glyph_index;
+
+			
+		}
+		currentWord = strtok(NULL, " ");
+	}
+}
+
+void sftd_draw_textf_wrap(sftd_font *font, int x, int y, unsigned int color, unsigned int size, unsigned int lineWidth, const char *text, ...)
+{
+	char buffer[256];
+	va_list args;
+	va_start(args, text);
+	vsnprintf(buffer, 256, text, args);
+	sftd_draw_text_wrap(font, x, y, color, size, lineWidth, buffer);
+	va_end(args);
+}

--- a/sample/source/main.c
+++ b/sample/source/main.c
@@ -24,18 +24,7 @@ int main()
 		sf2d_start_frame(GFX_TOP, GFX_LEFT);
 
 			sftd_draw_textf(font, 10, 10, RGBA8(0, 255, 0, 255), 20, "FPS %f", sf2d_get_fps());
-
-			sftd_draw_text(font, 10, 30,  RGBA8(255, 0,   0,   255), 20, "Font drawing on the top screen!");
-			sftd_draw_text(font, 10, 50,  RGBA8(0,   255, 0,   255), 15, "Font drawing on the top screen!");
-			sftd_draw_text(font, 10, 68,  RGBA8(0,   0,   255, 255), 25, "Font drawing on the top screen!");
-			sftd_draw_text(font, 10, 90,  RGBA8(255, 255, 0,   255), 10, "Font drawing on the top screen!");
-			sftd_draw_text(font, 10, 105, RGBA8(255, 0,   255, 255), 8, "Font drawing on the top screen!");
-			sftd_draw_text(font, 10, 120, RGBA8(0,   255, 255, 255), 30, "Font drawing on the top screen!");
-
-			sftd_draw_text(font, 10, 155, RGBA8(255, 0,   0,   255), 20, "Font drawing on the top screen!");
-			sftd_draw_text(font, 10, 170, RGBA8(0,   255, 0,   255), 2, "Font drawing on the top screen!");
-			sftd_draw_text(font, 10, 180, RGBA8(0,   0,   255, 255), 10, "Font drawing on the top screen!");
-			sftd_draw_text(font, 10, 205, RGBA8(255, 255, 0,   255), 170, "Font drawing on the top screen!");
+			sftd_draw_text_wrap(font, 10, 40,  RGBA8(255, 255, 255, 255), 20, 300, "Font drawing on the top screen! Text wraps after 300 pixels... Lorem ipsum dolor sit amet, consetetur sadipscing elit.");
 
 		sf2d_end_frame();
 

--- a/sample/source/main.c
+++ b/sample/source/main.c
@@ -16,6 +16,10 @@ int main()
 	sftd_init();
 	sftd_font *font = sftd_load_font_mem(FreeSans_ttf, FreeSans_ttf_size);
 
+	const char *someText = "Font drawing on the top screen! Text wraps after 300 pixels... Lorem ipsum dolor sit amet, consetetur sadipscing elit.";
+	int textWidth = 0;
+	int textHeight = 0;
+
 	while (aptMainLoop()) {
 
 		hidScanInput();
@@ -24,7 +28,9 @@ int main()
 		sf2d_start_frame(GFX_TOP, GFX_LEFT);
 
 			sftd_draw_textf(font, 10, 10, RGBA8(0, 255, 0, 255), 20, "FPS %f", sf2d_get_fps());
-			sftd_draw_text_wrap(font, 10, 40,  RGBA8(255, 255, 255, 255), 20, 300, "Font drawing on the top screen! Text wraps after 300 pixels... Lorem ipsum dolor sit amet, consetetur sadipscing elit.");
+			sftd_calc_bounding_box(&textWidth, &textHeight, font, 20, 300, someText);
+			sf2d_draw_rectangle(10, 40, textWidth, textHeight, RGBA8(0, 100, 0, 255));
+			sftd_draw_text_wrap(font, 10, 40,  RGBA8(255, 255, 255, 255), 20, 300, someText);
 
 		sf2d_end_frame();
 


### PR DESCRIPTION
ADDED: int sftd_get_text_width() A function to calculate the width of a text in pixels
ADDED: void sftd_draw_text_wrap() A function to draw text that word wraps after a given line length
UPDATED: Updated the sample to demonstrate the multiline text drawing.

Example:

``` c
sftd_draw_text_wrap(font, 10, 40,  RGBA8(255, 255, 255, 255), 20, 100, "New line after every 100px.");
```

![sftdlib_multiline](https://cloud.githubusercontent.com/assets/4057692/9810084/07482cb8-586e-11e5-83a4-13bc077b5bd7.png)
