### PR TITLE
'\r' is now handled by sftd_draw_text

### DIFF
--- a/libsftd/source/sftd.c
+++ b/libsftd/source/sftd.c
@@ -233,6 +233,10 @@ void sftd_draw_text(sftd_font *font, int x, int y, unsigned int color, unsigned 
 			text++;
 			continue;
 		}
+		if(*text == '\r') {
+			text++;
+			continue;
+		}
 
 		glyph_index = FTC_CMapCache_Lookup(font->cmapcache, (FTC_FaceID)font, charmap_index, *text);
 


### PR DESCRIPTION
I noticed that sftd doesn't handle carriage return as special character, and that it should be included to avoid unexpected characters while displaying the text (for example .txt files downloaded from the internet and stored in a char*). Including this modification, sftd_draw_text doesn't display unexpected characters related to carriage return anymore.
